### PR TITLE
fix: quote CLAUDE_PLUGIN_ROOT in hooks.json commands

### DIFF
--- a/claude/core-tools/hooks/hooks.json
+++ b/claude/core-tools/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/auto-approve-da-session.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/auto-approve-da-session.sh\"",
             "timeout": 5
           }
         ]

--- a/claude/dev-tools/hooks/hooks.json
+++ b/claude/dev-tools/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/resolve-cross-plugins.sh ${CLAUDE_PLUGIN_ROOT}",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/resolve-cross-plugins.sh\" \"${CLAUDE_PLUGIN_ROOT}\"",
             "timeout": 10
           }
         ]

--- a/claude/plugin-tools/hooks/hooks.json
+++ b/claude/plugin-tools/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/resolve-cross-plugins.sh ${CLAUDE_PLUGIN_ROOT}",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/resolve-cross-plugins.sh\" \"${CLAUDE_PLUGIN_ROOT}\"",
             "timeout": 10
           }
         ]

--- a/claude/sdd-tools/hooks/hooks.json
+++ b/claude/sdd-tools/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/auto-approve-session.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/auto-approve-session.sh\"",
             "timeout": 5
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/verify-task-completion.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/verify-task-completion.sh\"",
             "timeout": 120
           }
         ]
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/resolve-cross-plugins.sh ${CLAUDE_PLUGIN_ROOT}",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/resolve-cross-plugins.sh\" \"${CLAUDE_PLUGIN_ROOT}\"",
             "timeout": 10
           }
         ]

--- a/claude/tdd-tools/hooks/hooks.json
+++ b/claude/tdd-tools/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/auto-approve-session.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/auto-approve-session.sh\"",
             "timeout": 5
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/resolve-cross-plugins.sh ${CLAUDE_PLUGIN_ROOT}",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/resolve-cross-plugins.sh\" \"${CLAUDE_PLUGIN_ROOT}\"",
             "timeout": 10
           }
         ]


### PR DESCRIPTION
## Summary
- Wraps every `${CLAUDE_PLUGIN_ROOT}` reference in `command` strings in double quotes across `core-tools`, `sdd-tools`, `tdd-tools`, `dev-tools`, and `plugin-tools` `hooks/hooks.json`
- Fixes `PreToolUse` (matcher `Write|Edit|Bash`) failing on Windows when the user's home path contains a space, e.g. `C:\Users\Jane Doe\...` — Git Bash word-splits the unquoted variable and the hook errors with `bash: C:/Users/Jane: No such file or directory`, blocking every Bash/Edit/Write tool call

Fixes #16

## Test plan
- [x] `node -e "JSON.parse(...)"` validates syntax on all 5 changed files
- [x] Simulated the quoted invocation with a `CLAUDE_PLUGIN_ROOT` containing a space — resolves and runs (exit 0) instead of word-splitting
- [ ] Maintainer confirms on an actual Windows machine with a spaced username

🤖 Generated with [Claude Code](https://claude.com/claude-code)